### PR TITLE
Split large keyfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # registry-harvester
 Registry harvester that transforms registry people documents into a flat file format for loading into Symphony
 
+## Compile the java classes
+cd classes
 javac -cp .:../lib/sqljdbc4.jar:../lib/commons-io-2.4.jar:../lib/jdom-2.0.5.jar *.java
+
+## Copy /etc and /conf files from shared_configs

--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -4,12 +4,24 @@ HOME="/s/SUL/Harvester"
 LOG="$HOME/log"
 DATE=$1
 
-cd $HOME/classes
+KEY_DIR="/s/SUL/Batchlog"
+KEY_FILE="$KEY_DIR/userload.keys.$DATE"
 
 echo "Processing /s/SUL/Batchlog/userload.keys.$DATE for ILLiad" > $LOG/illiad.log
 
 echo "" >> $LOG/illiad.log
 
-java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad /s/SUL/Batchlog/userload.keys.$DATE >> $LOG/illiad.log  2>&1
+if [ $(grep -c "^[0-9]\+" $KEY_FILE) -gt 10000 ]
+then
+  cd $KEY_DIR
+  split -a 1 -l 5000 -d $KEY_FILE "userload.keys.$DATE."
+fi
+
+cd $HOME/classes
+
+for FILE in `find $KEY_DIR/userload.keys.$DATE*`
+do
+  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $FILE >> $LOG/illiad.log  2>&1
+done
 
 cat $LOG/illiad.log | mailx -s 'ILLiad User Export Log' sul-unicorn-devs@lists.stanford.edu


### PR DESCRIPTION
This change checks if the /s/SUL/Batchlog/userload.keys.$DATE file is larger than 5000 keys. If so, it will split the file into serveral and then do the user record export to ILLiad on each file. Tested successfully on morison to make sure it worked.

side note:
Also added more info to README to instruct how to compile the java classes and get the server-specific configuration files from sul-dlss/shared_configs