### PR TITLE
Split large keyfile

### DIFF
--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -15,13 +15,15 @@ if [ $(grep -c "^[0-9]\+" $KEY_FILE) -gt 10000 ]
 then
   cd $KEY_DIR
   split -a 1 -l 5000 -d $KEY_FILE "userload.keys.$DATE."
+
+  cd $HOME/classes
+
+  for FILE in `find $KEY_FILE.*`
+  do
+    java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $FILE >> $LOG/illiad.log  2>&1
+  done
+else
+  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $KEY_FILE > $LOG/illiad.log  2>&1
 fi
-
-cd $HOME/classes
-
-for FILE in `find $KEY_DIR/userload.keys.$DATE*`
-do
-  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $FILE >> $LOG/illiad.log  2>&1
-done
 
 cat $LOG/illiad.log | mailx -s 'ILLiad User Export Log' sul-unicorn-devs@lists.stanford.edu

--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -7,10 +7,6 @@ DATE=$1
 KEY_DIR="/s/SUL/Batchlog"
 KEY_FILE="$KEY_DIR/userload.keys.$DATE"
 
-echo "Processing /s/SUL/Batchlog/userload.keys.$DATE for ILLiad" > $LOG/illiad.log
-
-echo "" >> $LOG/illiad.log
-
 if [ $(grep -c "^[0-9]\+" $KEY_FILE) -gt 10000 ]
 then
   cd $KEY_DIR
@@ -20,9 +16,13 @@ then
 
   for FILE in `find $KEY_FILE.*`
   do
+    echo "Processing $FILE for ILLiad" > $LOG/illiad.log
+    echo "" >> $LOG/illiad.log
     java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $FILE >> $LOG/illiad.log  2>&1
   done
 else
+  echo "Processing $KEY_FILE for ILLiad" > $LOG/illiad.log
+  echo "" >> $LOG/illiad.log
   java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $KEY_FILE > $LOG/illiad.log  2>&1
 fi
 


### PR DESCRIPTION
The find command was also including the original (un-split) file, thus counteracting the whole point of the changes here, so the for loop only happens if the grep count is -gt 10K.