### PR TITLE
Check for duplicate keys in keyfile and log count of inserts/updates

### DIFF
--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -18,14 +18,24 @@ then
   do
     echo "Processing $FILE for ILLiad" > $LOG/illiad.log
     echo "" >> $LOG/illiad.log
-    java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $FILE >> $LOG/illiad.log  2>&1
+    cat $FILE | sort | uniq > ${FILE}_uniq
+    java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${FILE}_uniq >> $LOG/illiad.log  2>&1
   done
 else
   cd $HOME/classes
   
   echo "Processing $KEY_FILE for ILLiad" > $LOG/illiad.log
   echo "" >> $LOG/illiad.log
-  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad $KEY_FILE > $LOG/illiad.log  2>&1
+  cat $KEY_FILE | sort | uniq > ${KEY_FILE}_uniq
+  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${KEY_FILE}_uniq >> $LOG/illiad.log  2>&1
+fi
+
+if [ -z $(grep "Error" $LOG/illiad.log) ]
+then
+    VALUES=`grep "VALUES" $LOG/illiad.log | wc -l`
+    echo "" >> $LOG/illiad.log
+    echo "$VALUES rows inserted into ILLiad Users Table" >> $LOG/illiad.log
 fi
 
 cat $LOG/illiad.log | mailx -s 'ILLiad User Export Log' sul-unicorn-devs@lists.stanford.edu
+rm $KEY_DIR/userload.keys.*_uniq


### PR DESCRIPTION
Tested on morison:
```
sirsi@morison /s/SUL/Harvester/log> tail illiad.log.20160207.201602081315
 VALUES
('....','Sun','Naiyi','..........','Academic Staff','....@stanford.edu','','NULL','','ST2','','Electronic','Hold for Pickup','NULL','2016-02-08 13:16:18.252','SUL','Yes','Yes','','','','','','SUL','9999-01-01 00:00:00.0',NULL,NULL,'MED',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'ILLiad',NULL,NULL,NULL,NULL,NULL)

-----------
 VALUES
('........','Espeleta','Corazon','..........','Staff','........@stanford.edu','(...) ...-....','NULL','HandS Dean''s Office','ST2','','Electronic','Hold for Pickup','NULL','2016-02-08 13:16:18.252','SUL','Yes','Yes','','','','','','SUL','9999-01-01 00:00:00.0',NULL,NULL,'SUL',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'ILLiad',NULL,NULL,NULL,NULL,NULL)

-----------

484 rows inserted into ILLiad Users Table
```

![screen shot 2016-02-08 at 1 34 08 pm](https://cloud.githubusercontent.com/assets/3093850/12900045/1d567ca0-ce69-11e5-995e-e67a5ffb9f49.png)
