### PR TITLE
Add second argument to run script

### DIFF
--- a/classes/Pop2ILLiad.java
+++ b/classes/Pop2ILLiad.java
@@ -80,10 +80,8 @@ public class Pop2ILLiad {
 
             String selFlag = "U";
 
-            if (inputType != null){
-                if (inputType.indexOf("sunet") > -1){
-                    selFlag = "x";
-                }
+            if (inputType != null && inputType.indexOf("sunet") > -1) {
+                selFlag = "x";
             }
 
             //For each userkey in the userload.keys file

--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -19,15 +19,15 @@ then
     echo "Processing $FILE for ILLiad" > $LOG/illiad.log
     echo "" >> $LOG/illiad.log
     cat $FILE | sort | uniq > ${FILE}_uniq
-    java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${FILE}_uniq >> $LOG/illiad.log  2>&1
+    java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${FILE}_uniq keyfile >> $LOG/illiad.log  2>&1
   done
 else
   cd $HOME/classes
-  
+
   echo "Processing $KEY_FILE for ILLiad" > $LOG/illiad.log
   echo "" >> $LOG/illiad.log
   cat $KEY_FILE | sort | uniq > ${KEY_FILE}_uniq
-  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${KEY_FILE}_uniq >> $LOG/illiad.log  2>&1
+  java -cp .:../lib/commons-io-2.4.jar:../lib/sqljdbc4.jar Pop2ILLiad ${KEY_FILE}_uniq keyfile >> $LOG/illiad.log  2>&1
 fi
 
 if [ -z $(grep "Error" $LOG/illiad.log) ]


### PR DESCRIPTION
The error message:
```
Pop2ILLiad: 1
```
 means that the second arg got a nullPointerException. I added the argument 'keyfile' to the run script. As long as the second arg does not have 'sunet' it will set the 'U' flag.