### PR TITLE
Normalize the DEPT string so that ampersands become 'and'

### DIFF
--- a/classes/Pop2ILLiad.java
+++ b/classes/Pop2ILLiad.java
@@ -223,6 +223,10 @@ public class Pop2ILLiad {
                             sc.nextLine();
                         }
                     }
+                    
+                    if (DEPT.length() > 0) {
+                      DEPT = DEPT.replace("&", "and");
+                    }
                 }
                 catch (java.lang.ArrayIndexOutOfBoundsException a)
                 {}


### PR DESCRIPTION
@shelleydoljack Doing a string replace operation on the ampersand. This will have no effect on the current implementation since the string mappers already have 'and' in all of the strings.