### PR TITLE
Escapes apostrophes in department names.

### DIFF
--- a/classes/Pop2ILLiad.java
+++ b/classes/Pop2ILLiad.java
@@ -188,6 +188,7 @@ public class Pop2ILLiad {
 
                     if (department.length() > 0) {
                       department = department.replace("&", "and");
+                      department = department.replace("'","''");
                     }
                 }
                 catch (java.lang.ArrayIndexOutOfBoundsException a)


### PR DESCRIPTION
@jgreben I tested this with a user on test and it looks like the apostrophe is correctly replaced, but please confirm it is so in the illiad test database.