### PR TITLE
Make term for Winter 17 instead of 16 

### DIFF
--- a/classes/course/BuildCourseXML.java
+++ b/classes/course/BuildCourseXML.java
@@ -228,7 +228,7 @@ public class BuildCourseXML {
       System.err.println(e.getMessage());
     }
   }
-
+  
   public static void logAddition(Date time, String id) {
     try {
       BufferedWriter out = new BufferedWriter(new FileWriter(logFile, true));

--- a/classes/course/BuildCourseXML.java
+++ b/classes/course/BuildCourseXML.java
@@ -114,7 +114,8 @@ public class BuildCourseXML {
           String termComp = BuildTermString.getShortYear(term);
 
           if ( termComp.equals(yr) ||
-               (termComp.equals(nyr) && termStr.equals("F")) )
+               (termComp.equals(nyr) && termStr.equals("F")) ||
+               (termComp.equals(nyr) && termStr.equals("W")) )
           {
             if (termStr.equals("SU")){
               addOrSetContentForTerm(summer, lineNew, id, "summer");

--- a/classes/course/BuildCourseXML.java
+++ b/classes/course/BuildCourseXML.java
@@ -66,7 +66,8 @@ public class BuildCourseXML {
             spring.add(fileLine);
             System.err.println("spring size:" + spring.size());
           }
-          if(quarter[t].equals("winter") && fileLine.indexOf("term=\"1"+yr+"4\"") > 0) {
+          if(quarter[t].equals("winter") &&
+            (fileLine.indexOf("term=\"1"+yr+"4\"") > 0) || fileLine.indexOf("term=\"1"+nyr+"4\"") > 0) {
             winter.add(fileLine);
             System.err.println("winter size:" + winter.size());
           }
@@ -228,7 +229,7 @@ public class BuildCourseXML {
       System.err.println(e.getMessage());
     }
   }
-  
+
   public static void logAddition(Date time, String id) {
     try {
       BufferedWriter out = new BufferedWriter(new FileWriter(logFile, true));

--- a/classes/course/BuildTermString.java
+++ b/classes/course/BuildTermString.java
@@ -58,7 +58,9 @@ public class BuildTermString {
     if (getTerm(term).equals("F")) {
       year = year - 1;
     }
-
+    if (getTerm(term).equals("W")) {
+      year = year + 1;
+    }
     result = century + String.valueOf(year);
     return result;
   }
@@ -70,7 +72,9 @@ public class BuildTermString {
     if (getTerm(term).equals("F")) {
       year = year - 1;
     }
-
+    if (getTerm(term).equals("W")) {
+      year = year + 1;
+    }
     result = String.valueOf(year);
     return result;
   }

--- a/classes/course/BuildTermString.java
+++ b/classes/course/BuildTermString.java
@@ -58,9 +58,6 @@ public class BuildTermString {
     if (getTerm(term).equals("F")) {
       year = year - 1;
     }
-    if (getTerm(term).equals("W")) {
-      year = year + 1;
-    }
     result = century + String.valueOf(year);
     return result;
   }
@@ -71,9 +68,6 @@ public class BuildTermString {
     int year = Integer.parseInt(academicYear);
     if (getTerm(term).equals("F")) {
       year = year - 1;
-    }
-    if (getTerm(term).equals("W")) {
-      year = year + 1;
     }
     result = String.valueOf(year);
     return result;


### PR DESCRIPTION
(which matches the code in the registry coded year, e.g. 1164)

@shelleydoljack can you merge this when you get a chance. The registry data has 1164 for the coded term, but I think this should translate to Winter 17 not 16. Otherwise it makes no sense that we would be harvesting a course from last year. I guess that the code is generated as 1164 because it is harvested this year for a quarter that happens next year.