### PR TITLE
Keeps more than yesterday's course build files.

### DIFF
--- a/run/course-build
+++ b/run/course-build
@@ -39,7 +39,8 @@ then
 fi
 
 cp $HOME/include/courses/*.xml $HOME/include/courses/LastRun/
-cp $DATA/*.xml $DATA/LastRun/
+mkdir $DATA/LastRun$DATE
+cp -p $DATA/*.xml $DATA/LastRun$DATE/
 
 cd $HOME/classes
 


### PR DESCRIPTION
@jgreben I'm trying to track down why we are getting reports of courses missing so keeping more than yesterday's course build file should help.