### PR TITLE
Remove carriage returns from report file using perl utility.

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,4 @@
-server "bodoni.stanford.edu", user: "#{fetch(:user)}", roles: %w{app db web}
+server "symphony-app-prod-1.stanford.edu", user: "#{fetch(:user)}", roles: %w{app db web}
 
 # allow ssh to host
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/run/do-harvest
+++ b/run/do-harvest
@@ -3,6 +3,7 @@
 . /s/SUL/Config/sirsi.env
 
 HOME=/s/SUL/Harvester/current
+REM_CR=/s/SUL/Bin/TextUtil/remove_cr.pl
 LOG=$HOME/log
 OUT=$HOME/out
 DATE=$1
@@ -22,7 +23,7 @@ illiad_date=`/s/sirsi/Unicorn/Bin/transdate -d-1`
 echo "Updating/Inserting keys from /s/SUL/Batchlog/userload.keys.$illiad_date into ILLiad" >> $LOG/harvest.log
 $HOME/run/pop2illiad $illiad_date
 
-cat $LOG/harvest.log | mailx -s 'Harvest Log' sul-unicorn-devs@lists.stanford.edu
+cat $LOG/harvest.log | $REM_CR | mailx -s 'Harvest Log' sul-unicorn-devs@lists.stanford.edu
 
 mv $LOG/harvest.log $LOG/harvest.log.$DATE
 mv $OUT/harvest.out $OUT/harvest.out.$DATE


### PR DESCRIPTION
Also use the name of the server for cap deploys instead of hostname to avoid local connection issues.