### PR TITLE
Prepend MED to user Status field when populating ILLiad User table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,24 +2,24 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    airbrussh (1.3.0)
+    airbrussh (1.3.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    backports (3.8.0)
-    byebug (9.1.0)
-    capistrano (3.9.1)
+    backports (3.11.4)
+    capistrano (3.11.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-one_time_key (0.0.1)
+    capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    ethon (0.10.1)
+    concurrent-ruby (1.1.3)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
-    faraday (0.13.1)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.18)
+    ffi (1.9.25)
     gh (0.15.1)
       addressable (~> 2.4.0)
       backports
@@ -27,26 +27,27 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (~> 2.9)
       net-http-pipeline
-    highline (1.7.8)
-    i18n (0.8.6)
+    highline (1.7.10)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    multi_json (1.12.2)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
+    net-ssh (5.0.2)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rake (12.1.0)
-    sshkit (1.14.0)
+    rake (12.3.1)
+    sshkit (1.18.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    travis (1.8.8)
+    travis (1.8.9)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
@@ -57,16 +58,15 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    websocket (1.2.4)
+    websocket (1.2.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   capistrano
   capistrano-one_time_key
   travis
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/Person/src/main/java/edu/stanford/Pop2ILLiad.java
+++ b/Person/src/main/java/edu/stanford/Pop2ILLiad.java
@@ -99,6 +99,11 @@ public class Pop2ILLiad {
                 String nvtgc = ""; //7 Y.9032.
                 String expiration = ""; //8 e
 
+                // NOTE: "nvtgc" is the code for the user's ILLiad instance that comes out of the registry userload
+                // and writen into the symphony user record in a custom user field as "gsb", "law", or "medicine" based
+                // on the user's privgroup statuses (see <xsl:template match="privgroup"> in xslt/library_patron.xsl).
+                // "NVTGC" is the code that gets set in the ILLiad user record via ILLData.put below...
+
                 String NVTGC = "";
                 String organization = "";
                 String fullName = "";
@@ -173,6 +178,10 @@ public class Pop2ILLiad {
 
                 if (status.length() == 0) {
                   status = "Affiliate";
+                }
+
+                if (organization.equals("MED")) {
+                    status = "MED " + status;
                 }
 
                 if (department.length() > 0) {

--- a/Person/src/main/java/edu/stanford/Pop2ILLiad.java
+++ b/Person/src/main/java/edu/stanford/Pop2ILLiad.java
@@ -176,7 +176,7 @@ public class Pop2ILLiad {
                     }
                 }
 
-                if (status.length() == 0) {
+                if (status == null || status.length() == 0) {
                   status = "Affiliate";
                 }
 


### PR DESCRIPTION
https://github.com/sul-dlss/LibSysTasks/issues/393

Adds prefix `MED` to the user's status if they have `organization:med` from their registry privgroup. Adds comments about use and provenance of NVTGC. Fixes issues with maven assembly and cap deploy.