### PR TITLE
Adds sirsi env

### DIFF
--- a/run/pop2illiad
+++ b/run/pop2illiad
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /s/SUL/Config/sirsi.env
+
 HOME=/s/SUL/Harvester/current
 REM_CR=/s/SUL/Bin/TextUtil/remove_cr.pl
 LOG=$HOME/log


### PR DESCRIPTION
The java program called in the pop2illiad script uses seluser, so we need to pass the sirsi environment to it.