### PR TITLE
Changes ILLiad AuthType field from ILLiad to RemoteAuth for ILLiad v9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - oraclejdk8
 cache:

--- a/Person/src/main/java/edu/stanford/Pop2ILLiad.java
+++ b/Person/src/main/java/edu/stanford/Pop2ILLiad.java
@@ -245,7 +245,7 @@ public class Pop2ILLiad {
                     illData.put("PasswordHint", "NULL"); //
                     illData.put("SCountry", "NULL"); //
                     illData.put("RSSID", "NULL");
-                    illData.put("AuthType", "'ILLiad'");
+                    illData.put("AuthType", "'RemoteAuth'");
                     illData.put("UserInfo1", "NULL"); //
                     illData.put("UserInfo2", "NULL"); //
                     illData.put("UserInfo3", "NULL"); //


### PR DESCRIPTION
Changes two things: 
 - updates the contents of an ILLiad field as required by new version
 - sets the ubuntu travis distribution for running build so that oracle install does not fail (travis has changed the default dist).