### PR TITLE
Make sure script exits when run from command line

### DIFF
--- a/run/fileLoad.sh
+++ b/run/fileLoad.sh
@@ -45,6 +45,8 @@ EXIT_CODE=$?
 
 if [ $EXIT_CODE -gt 0 ] ; then
   echo "Processor exited abnormally. Check log file for details"
+  exit $EXIT_CODE
 else
   echo "Processor exited successfully"
+  exit 0
 fi


### PR DESCRIPTION
Since we never really run this, when I ran it, the script hangs at the end and I had to use ctrl-c.