### PR TITLE
Fixes call to xml transform command in person harvester scripts

### DIFF
--- a/run/do-harvest
+++ b/run/do-harvest
@@ -26,7 +26,7 @@ sed -i '/^$/d' $OUT/harvest.xml.out
 # TODO: run $OUT/harvest.xml.out through folio_user_load ruby script
 
 # Generate the flat file for Symphony
-java -cp ../lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out xml $XSLT/library_patron.xsl > $OUT/harvest.out
+java -cp $HOME/lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out $XSLT/library_patron.xsl > $OUT/harvest.out
 
 # Fix up the harvest.out files
 $HOME/run/usertrans $DATE

--- a/run/do-harvest-file
+++ b/run/do-harvest-file
@@ -27,7 +27,7 @@ sed -i '/^$/d' $OUT/harvest.xml.out
 # TODO: run $OUT/harvest.xml.out through folio_user_load ruby script
 
 # Generate the flat file for Symphony
-java -cp ../lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out xml $XSLT/library_patron.xsl > $OUT/harvest.out
+java -cp $HOME/lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out $XSLT/library_patron.xsl > $OUT/harvest.out
 
 # Fix up the harvest.out files
 $HOME/run/usertrans $DATE


### PR DESCRIPTION
There was an extra argument in the command that calls the xslt transformer, so the userload flat file was not being generated. Also, makes the path to the command absolute.