### PR TITLE
Upgrade for MaIS host and script fixes

### DIFF
--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -12,10 +12,6 @@ FOLIO=/s/SUL/Bin/folio_api_client/current
 KEYS=$2
 DATE=$3
 
-if [[ ! "$IS_PRODUCTION" ]]; then
-  UAT="-uat"
-fi
-
 # Run the registry harvest
 if [[ $1 == 'file' ]]; then
   $HOME/run/person_file_load.sh $KEYS

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -28,14 +28,11 @@ if [[ -z $DATE ]]; then
 fi
 
 # Remove carriage returns from the log
-perl -p -i -e 's/\r//g' $LOG/harvest.log
+sed -i '/\r/d' $LOG/harvest.log
 
-# Use this when using the LibraryPatron Java xslt transformer instead of the packaged one provided by MaIS
-if [[ head -1 $OUT/harvest.xml.out | grep 'DOCTYPE' ]]; then
-  sed -i '1d' $OUT/harvest.xml.out
-fi
-
+# Use the LibraryPatron Java xslt transformer instead of the packaged one provided by MaIS to get the raw xml lines
 # Generate the flat file for Symphony
+sed -i '/DOCTYPE Person SYSTEM/d' $OUT/harvest.xml.out
 java -cp $HOME/lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out $XSLT/library_patron.xsl > $OUT/harvest.out
 
 # Fix up the harvest.out files

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -52,7 +52,7 @@ if [[ $FOLIO ]]; then
   batch=0
   while mapfile -t -n 1000 array && ((${#array[@]}))
   do
-      batch++
+      let batch=batch+1
       printf '%s\n' "${array[@]}" > $OUT/tmp.xml
       echo "----------batch ${batch}----------" >> $LOG/folio.log
       STAGE="${STAGE}" ruby bin/folio_user.rb $OUT/tmp.xml >> $LOG/folio.log 2> $LOG/folio_err.log

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -31,8 +31,9 @@ fi
 perl -p -i -e 's/\r//g' $LOG/harvest.log
 
 # Use this when using the LibraryPatron Java xslt transformer instead of the packaged one provided by MaIS
-perl -p -i -e "s/<!DOCTYPE Person SYSTEM \"http:\/\/registry${UAT}.stanford.edu\/xml\/person\/1.2\/Person.dtd\">//g" $OUT/harvest.xml.out
-sed -i '/^$/d' $OUT/harvest.xml.out
+if [[ head -1 $OUT/harvest.xml.out | grep 'DOCTYPE' ]]; then
+  sed -i '1d' $OUT/harvest.xml.out
+fi
 
 # Generate the flat file for Symphony
 java -cp $HOME/lib/Person-jar-with-dependencies.jar edu.stanford.LibraryPatron $OUT/harvest.xml.out $XSLT/library_patron.xsl > $OUT/harvest.out

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -54,7 +54,7 @@ if [[ $FOLIO ]]; then
   do
       let batch=batch+1
       printf '%s\n' "${array[@]}" > $OUT/tmp.xml
-      echo "----------batch ${batch}----------" >> $LOG/folio.log
+      echo "----------batch ${batch}: ${#array[@]} records ----------" >> $LOG/folio.log
       STAGE="${STAGE}" ruby bin/folio_user.rb $OUT/tmp.xml >> $LOG/folio.log 2> $LOG/folio_err.log
       rm $OUT/tmp.xml
   done < $OUT/harvest.xml.out

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -49,9 +49,12 @@ $HOME/run/pop2illiad.sh $illiad_date
 if [[ $FOLIO ]]; then
   cd $FOLIO
   # Split into batches of 1000
+  batch=0
   while mapfile -t -n 1000 array && ((${#array[@]}))
   do
+      batch++
       printf '%s\n' "${array[@]}" > $OUT/tmp.xml
+      echo "----------batch ${batch}----------" >> $LOG/folio.log
       STAGE="${STAGE}" ruby bin/folio_user.rb $OUT/tmp.xml >> $LOG/folio.log 2> $LOG/folio_err.log
       rm $OUT/tmp.xml
   done < $OUT/harvest.xml.out

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -62,7 +62,7 @@ fi
 
 # Email and move/reset work files
 cat $LOG/harvest.log | mailx -s 'Harvest Log' sul-unicorn-devs@lists.stanford.edu
-cat $LOG/folio.log | mailx -s 'Folio User Load' sul-unicorn-devs@lists.stanford.edu
+cat $LOG/folio_err.log $LOG/folio.log | mailx -s 'Folio User Load' sul-unicorn-devs@lists.stanford.edu
 
 # Save output files
 mv $OUT/harvest.out $OUT/harvest.out.$DATE

--- a/run/do-person-harvest.sh
+++ b/run/do-person-harvest.sh
@@ -48,11 +48,11 @@ $HOME/run/pop2illiad.sh $illiad_date
 # Run harvest.xml.out through folio_api_client ruby script to load users into FOLIO
 if [[ $FOLIO ]]; then
   cd $FOLIO
-  Split into batches of 5000
-  while mapfile -t -n 5000 array && ((${#array[@]}))
+  # Split into batches of 1000
+  while mapfile -t -n 1000 array && ((${#array[@]}))
   do
       printf '%s\n' "${array[@]}" > $OUT/tmp.xml
-      STAGE="${STAGE}" ruby bin/folio_user.rb $OUT/tmp.xml >> $LOG/folio.log 2>&1
+      STAGE="${STAGE}" ruby bin/folio_user.rb $OUT/tmp.xml >> $LOG/folio.log 2> $LOG/folio_err.log
       rm $OUT/tmp.xml
   done < $OUT/harvest.xml.out
 fi
@@ -69,10 +69,12 @@ mv $OUT/harvest.xml.out $OUT/harvest.xml.out.$DATE
 mv $LOG/harvest.log $LOG/harvest.log.$DATE
 mv $LOG/illiad.log $LOG/illiad.log.$illiad_date.$DATE
 mv $LOG/folio.log $LOG/folio.log.$DATE
+mv $LOG/folio_err.log $LOG/folio_err.log.$DATE
 
 touch $LOG/harvest.log
 touch $LOG/illiad.log
 touch $LOG/folio.log
+touch $LOG/folio_err.log
 
 usage(){
     echo "Usage: $0 [ no argument | 'file' ] [ file of user keys (if arg0 == file) ] [ DATE (optional: to append to log and out files) ]"

--- a/run/person_runonce.sh
+++ b/run/person_runonce.sh
@@ -47,7 +47,7 @@ done
 # well as the name of its property file be specified as a command-line argument
 # -Dlog4j.configuration=<property file>
 #
-echo "ADDING wlthint3client-12.2.1.jar" >> $HARNESS_LOG
+echo "ADDING wlthint3client jar" >> $HARNESS_LOG
 CLASSPATH="$APP_HOME/WebLogic_lib/wlthint3client-14.1.1.jar":${CLASSPATH}:$CONF_HOME
 
 # This block will allow the harvester to run continuously as a service

--- a/run/person_runonce.sh
+++ b/run/person_runonce.sh
@@ -27,7 +27,7 @@ export LD_LIBRARY_PATH
 
 # looping to build classpath. skipping anything named old.*.jar
 #
-#
+# Support jar files
 echo "$t_stamp harness building classpath" >> $HARNESS_LOG
 for file in `ls $APP_HOME/jar/` ; do
  case "$file" in
@@ -41,14 +41,26 @@ for file in `ls $APP_HOME/jar/` ; do
         ;;
  esac
 done
-
+#
+# Weblogic jar file
+for file in `ls $APP_HOME/WebLogic_lib/` ; do
+ case "$file" in
+  old.*.jar) echo skipping $file >>$HARNESS_LOG;;
+  *.jar|*.zip) echo ADDING $file >> $HARNESS_LOG
+        if [ "$CLASSPATH" != "" ]; then
+           CLASSPATH=${CLASSPATH}:$APP_HOME/WebLogic_lib/$file
+        else
+           CLASSPATH=$APP_HOME/WebLogic_lib/$file
+        fi
+        ;;
+ esac
+done
 #
 # Log4j requires that its property file be specified in the CLASSPATH as
 # well as the name of its property file be specified as a command-line argument
 # -Dlog4j.configuration=<property file>
 #
-echo "ADDING wlthint3client jar" >> $HARNESS_LOG
-CLASSPATH="$APP_HOME/WebLogic_lib/wlthint3client-14.1.1.jar":${CLASSPATH}:$CONF_HOME
+CLASSPATH=${CLASSPATH}:$CONF_HOME
 
 # This block will allow the harvester to run continuously as a service
 #

--- a/run/person_runonce.sh
+++ b/run/person_runonce.sh
@@ -48,7 +48,7 @@ done
 # -Dlog4j.configuration=<property file>
 #
 echo "ADDING wlthint3client-12.2.1.jar" >> $HARNESS_LOG
-CLASSPATH="$APP_HOME/WebLogic_lib/wlthint3client-12.2.1.jar":${CLASSPATH}:$CONF_HOME
+CLASSPATH="$APP_HOME/WebLogic_lib/wlthint3client-14.1.1.jar":${CLASSPATH}:$CONF_HOME
 
 # This block will allow the harvester to run continuously as a service
 #


### PR DESCRIPTION
This branch is currently deployed on Morison.

- Use `sed` in `do-person-harvest` script to fix up xml lines
- Add a batch counter to the folio load log and redirect warnings/errors to folio_error log 
- Allow use of new weblogic client for new MaIS host by adding the weblogic jar files that actually exist in the folder to the classpath. Previously the client jar was hard-coded in the script.

Currently on Morison:
```
sirsi@symphony-app-dev-1 /s/SUL/Harvester/current/WebLogic_lib> ls
wlthint3client-14.1.1.jar
```

Currently on Bodoni:
```
sirsi@bodoni /s/SUL/Harvester/current/WebLogic_lib> ls
old.wlfullclient-10.3.5.jar  wlthint3client-12.2.1.jar
```