### PR TITLE
Fix directory package name

### DIFF
--- a/Person/src/test/edu/stanford/LibraryPatronTest.java
+++ b/Person/src/test/edu/stanford/LibraryPatronTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 public class LibraryPatronTest {
     private File xslt_file;
-    
+
     @Before
     public void init() {
         xslt_file = new File(getClass().getClassLoader().getResource("library_patron.xsl").getFile());


### PR DESCRIPTION
Not sure what happened, but the edu.stanford dot syntax broke the tests.