### PR TITLE
Send folio userload email as securemail

### DIFF
--- a/run/folio-userload.sh
+++ b/run/folio-userload.sh
@@ -30,7 +30,7 @@ if [[ $FOLIO ]]; then
   STAGE="${STAGE}" rake users:deactivate_users > $LOG/folio_inactive.log 2>&1
 fi
 
-cat $LOG/folio_err.log $LOG/folio.log | mailx -s 'Folio User Load' sul-unicorn-devs@lists.stanford.edu
+cat $LOG/folio_err.log $LOG/folio.log | mailx -s 'Secure: Folio User Load' sul-unicorn-devs@lists.stanford.edu
 
 # Save and reset log files
 mv $LOG/folio.log $LOG/folio.log.$DATE


### PR DESCRIPTION
Sometimes we get :Email message blocked" due to PII when sending the folio userload email. This is what the email blocked message says:
`
When sending High Risk Data in the body of an email or as an attachment, always insert "Secure:" in the subject line to send the message securely.  While “secure:” is not case sensitive and can appear anywhere in the subject line, the trailing colon with no space between is required to trigger the secure email service.  See https://secureemail.stanford.edu/ for more information.`